### PR TITLE
Updates from previous PR

### DIFF
--- a/STEP_Project/background.js
+++ b/STEP_Project/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onInstalled.addListener(function()
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
       chrome.declarativeContent.onPageChanged.addRules([{
         conditions: [new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: {urlMatches: '.*admin.google.com\/[u\/[0-9]+\/]?ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(settings\/serviceonoff)'},
+          pageUrl: {urlMatches: '.*admin.google.com\/(u\/[0-9]+\/)?ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(settings\/serviceonoff)'},
         })
         ],
             actions: [new chrome.declarativeContent.ShowPageAction()]

--- a/STEP_Project/background.js
+++ b/STEP_Project/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onInstalled.addListener(function()
   chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
       chrome.declarativeContent.onPageChanged.addRules([{
         conditions: [new chrome.declarativeContent.PageStateMatcher({
-          pageUrl: {urlMatches: '.*admin.google.com\/u\/[0-9]+\/ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(settings/serviceonoff)'},
+          pageUrl: {urlMatches: '.*admin.google.com\/[u\/[0-9]+\/]?ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(settings\/serviceonoff)'},
         })
         ],
             actions: [new chrome.declarativeContent.ShowPageAction()]

--- a/STEP_Project/popup.js
+++ b/STEP_Project/popup.js
@@ -24,12 +24,13 @@ function findPagecase(givenurl)
   let orgunitspage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/orgunits/g);
   let settingspage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/appsettings\/[0-9]+\/.+/g);
   let onoffpage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/settings\/serviceonoff.*/g);
+  let firstsettingspage = givenurl.match(/admin.google.com\/ac\/appsettings\/[0-9]+\/.+/g);
   pageType = PAGE_TYPES.OTHER;
   if (orgunitspage !== null) 
   {
     pageType = PAGE_TYPES.ORG_LIST_PAGE;
   }
-  else if (settingspage !== null || onoffpage !== null)
+  else if (settingspage !== null || onoffpage !== null || firstsettingspage != null)
   {
     pageType = PAGE_TYPES.SETTINGS_PAGE;
   }

--- a/STEP_Project/popup.js
+++ b/STEP_Project/popup.js
@@ -21,16 +21,15 @@ const PAGE_TYPES = {
  */
 function findPageType(givenurl)
 {
-  let orgunitspage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/orgunits/g);
-  let settingspage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/appsettings\/[0-9]+\/.+/g);
-  let onoffpage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/settings\/serviceonoff.*/g);
-  let firstsettingspage = givenurl.match(/admin.google.com\/ac\/appsettings\/[0-9]+\/.+/g);
+  let orgunitspage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/orgunits/g);
+  let settingspage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/appsettings\/[0-9]+\/.+/g);
+  let onoffpage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/settings\/serviceonoff.*/g);
   pageType = PAGE_TYPES.OTHER;
   if (orgunitspage !== null) 
   {
     pageType = PAGE_TYPES.ORG_LIST_PAGE;
   }
-  else if (settingspage !== null || onoffpage !== null || firstsettingspage != null)
+  else if (settingspage !== null || onoffpage !== null)
   {
     pageType = PAGE_TYPES.SETTINGS_PAGE;
   }

--- a/STEP_Project/popup.js
+++ b/STEP_Project/popup.js
@@ -19,7 +19,7 @@ const PAGE_TYPES = {
  * Checks url of the current tab to detect settings or OU list page
  * @param {string} givenurl - url of current page
  */
-function findPagecase(givenurl)
+function findPageType(givenurl)
 {
   let orgunitspage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/orgunits/g);
   let settingspage = givenurl.match(/admin.google.com\/u\/[0-9]+\/ac\/appsettings\/[0-9]+\/.+/g);
@@ -45,7 +45,7 @@ function checkTabUrl()
   chrome.tabs.query({active: true, lastFocusedWindow: true}, tabs => 
   {
     let url = tabs[0].url;
-    findPagecase(url);
+    findPageType(url);
   });
   waitForPagecase();
 }

--- a/STEP_Project/tests/popupTest.html
+++ b/STEP_Project/tests/popupTest.html
@@ -10,8 +10,6 @@
     <script src="../popup.js"></script>
 </head>
 <body>
-    <button id = "addRemove">mock add/remove button</button>
-    <button id = "select">mock select button</button>
 </body>
 </html>
 

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -1,29 +1,29 @@
 let ar = document.getElementById("addRemove");
 let s = document.getElementById("select");
 /**
- * testing function findPagecase
+ * testing function findPageType
  */
 describe('Testing pageType that determines enabling/disabling of buttons depending on URL', ()=>{
   it('Should enable Settings button on appSettings url (case 1)', ()=>{
-    let pageType = findPagecase("https://admin.google.com/u/4/ac/appsettings/725740718362/videoSettings");
+    let pageType = findPageType("https://admin.google.com/u/4/ac/appsettings/725740718362/videoSettings");
     expect(pageType).toEqual(1);
   })
 
   it('Should enable Settings button on settings/serviceonoff url (case 1)', ()=>{
-    let pageType = findPagecase("https://admin.google.com/u/4/ac/settings/serviceonoff?iid=646&aid=725740718362");
+    let pageType = findPageType("https://admin.google.com/u/4/ac/settings/serviceonoff?iid=646&aid=725740718362");
     expect(pageType).toEqual(1);
   })
 
   it('Should enable Add/Remove button on OUlist url (case 0)', ()=>{
-    let pageType = findPagecase("https://admin.google.com/u/4/ac/orgunits");
+    let pageType = findPageType("https://admin.google.com/u/4/ac/orgunits");
     expect(pageType).toEqual(0);
   })
   it('Should disable extension on any other admin console url (case 2)', ()=>{
-    let pageType = findPagecase("https://admin.google.com/u/4/ac/apps");
+    let pageType = findPageType("https://admin.google.com/u/4/ac/apps");
     expect(pageType).toEqual(2);
   })
   it('Should disable extension on any other console url (case 2)', ()=>{
-    let pageType = findPagecase("https://github.com/");
+    let pageType = findPageType("https://github.com/");
     expect(pageType).toEqual(2);
   })
 })

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -36,26 +36,33 @@ describe('Testing pageType that determines enabling/disabling of buttons dependi
 /**
  * testing function disableButtons
  */
+function initTest()
+{
+  const arButton = document.createElement('BUTTON')
+  arButton.setAttribute("id", "addRemove");
+  const sButton = document.createElement('BUTTON')
+  sButton.setAttribute("id", "select");
+  document.body.appendChild(arButton);
+  document.body.appendChild(sButton);
+  s = document.getElementById("select");
+  ar = document.getElementById("addRemove");
+}
+function restoreDOM()
+{
+  document.getElementById("select").remove();
+  document.getElementById("addRemove").remove();
+}
 
 describe('Testing enabling and disabling of buttons depending on pageType', ()=>
 {
   beforeEach(function() 
   {
-    //back to default for future tests
-    const arButton = document.createElement('BUTTON')
-    arButton.setAttribute("id", "addRemove");
-    const sButton = document.createElement('BUTTON')
-    sButton.setAttribute("id", "select");
-    document.body.appendChild(arButton);
-    document.body.appendChild(sButton);
-    s = document.getElementById("select");
-    ar = document.getElementById("addRemove");
+    initTest();
   });
 
   afterEach(function() 
   {
-    document.getElementById("select").remove();
-    document.getElementById("addRemove").remove();
+    restoreDOM();
   });
 
   it('Should disable add/remove button on settings url for pageType 1', ()=>{ 

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -42,21 +42,20 @@ describe('Testing enabling and disabling of buttons depending on pageType', ()=>
   beforeEach(function() 
   {
     //back to default for future tests
+    const arButton = document.createElement('BUTTON')
+    arButton.setAttribute("id", "addRemove");
+    const sButton = document.createElement('BUTTON')
+    sButton.setAttribute("id", "select");
+    document.body.appendChild(arButton);
+    document.body.appendChild(sButton);
     s = document.getElementById("select");
     ar = document.getElementById("addRemove");
   });
 
   afterEach(function() 
   {
-    //back to default for future tests
-    if (s !== null)
-    {
-      s.disabled = false;
-    }
-    if (ar !== null)
-    {
-      ar.disabled = false;
-    }
+    document.getElementById("select").remove();
+    document.getElementById("addRemove").remove();
   });
 
   it('Should disable add/remove button on settings url for pageType 1', ()=>{ 
@@ -73,7 +72,5 @@ describe('Testing enabling and disabling of buttons depending on pageType', ()=>
     disableButtons(s, ar, 2);
     expect(s.disabled).toBeFalsy();
     expect(ar.disabled).toBeFalsy();
-    s.remove();
-    ar.remove();
   })
 })

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -14,6 +14,11 @@ describe('Testing pageType that determines enabling/disabling of buttons dependi
     expect(pageType).toEqual(1);
   })
 
+  it('Should enable Settings button on appsettings url WITHOUT u/[num](case 1)', ()=>{
+    let pageType = findPageType("https://admin.google.com/ac/appsettings/725740718362/videoSettings");
+    expect(pageType).toEqual(1);
+  })
+
   it('Should enable Add/Remove button on OUlist url (case 0)', ()=>{
     let pageType = findPageType("https://admin.google.com/u/4/ac/orgunits");
     expect(pageType).toEqual(0);

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -1,5 +1,4 @@
-let ar = document.getElementById("addRemove");
-let s = document.getElementById("select");
+
 /**
  * testing function findPageType
  */
@@ -38,15 +37,14 @@ describe('Testing pageType that determines enabling/disabling of buttons dependi
  */
 function initTest()
 {
-  const arButton = document.createElement('BUTTON')
-  arButton.setAttribute("id", "addRemove");
-  const sButton = document.createElement('BUTTON')
-  sButton.setAttribute("id", "select");
-  document.body.appendChild(arButton);
-  document.body.appendChild(sButton);
-  s = document.getElementById("select");
-  ar = document.getElementById("addRemove");
+  const addRemoveButton = document.createElement('BUTTON')
+  addRemoveButton.setAttribute("id", "addRemove");
+  const selectButton = document.createElement('BUTTON')
+  selectButton.setAttribute("id", "select");
+  document.body.appendChild(addRemoveButton);
+  document.body.appendChild(selectButton);
 }
+
 function restoreDOM()
 {
   document.getElementById("select").remove();
@@ -58,6 +56,8 @@ describe('Testing enabling and disabling of buttons depending on pageType', ()=>
   beforeEach(function() 
   {
     initTest();
+    selectButton = document.getElementById("select");
+    addRemoveButton = document.getElementById("addRemove");
   });
 
   afterEach(function() 
@@ -66,18 +66,18 @@ describe('Testing enabling and disabling of buttons depending on pageType', ()=>
   });
 
   it('Should disable add/remove button on settings url for pageType 1', ()=>{ 
-    disableButtons(s, ar, 1);
-    expect(ar.disabled).toBeTruthy();
+    disableButtons(selectButton, addRemoveButton, 1);
+    expect(addRemoveButton.disabled).toBeTruthy();
   })
 
   it('Should disable select button on settings url for pageType 0', ()=>{ 
-    disableButtons(s, ar, 0);
-    expect(s.disabled).toBeTruthy();
+    disableButtons(selectButton, addRemoveButton, 0);
+    expect(selectButton.disabled).toBeTruthy();
   })
 
   it('Should disable neither buttons for pageType 2 as any other url disables extension', ()=>{ 
-    disableButtons(s, ar, 2);
-    expect(s.disabled).toBeFalsy();
-    expect(ar.disabled).toBeFalsy();
+    disableButtons(selectButton, addRemoveButton, 2);
+    expect(selectButton.disabled).toBeFalsy();
+    expect(addRemoveButton.disabled).toBeFalsy();
   })
 })


### PR DESCRIPTION
From the previous **popup.js** PR, some changes were requested after PR was closed. Those changes have been made in this PR. 

- URL for appsettings without u/\<num\> were added. Example: https://admin.google.com/ac/appsettings/725740718362/videoSettings is now a valid URL 
- Test case for this new URL form was added, and tests were passed. 
<img width="737" alt="image" src="https://user-images.githubusercontent.com/44329307/86441018-275df800-bd29-11ea-9570-6ff60a47cef5.png">

- The _findPagecase_ function was renamed to _findPageType_ in all files. 

- Dynamically create and remove mock buttons from the DOM for testing using _createElement_ and _remove()_ in the _beforeEach_ and _afterEach_ sections of Jasmine testing.