### PR TITLE
Static popup window from group/users/OU and navigation between windows

### DIFF
--- a/STEP_Project/entitySelect.html
+++ b/STEP_Project/entitySelect.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<link href="./style.css" rel="stylesheet" >
+</head>
+<body>
+    <p>Preferred Entity Selector</p>
+    <a class = "backButton" href = "popup.html"> &#x2190; </a>
+    
+    <a href = preferred.html> 
+        <button id = "OUs" class = "blueButton">ORGANIZATIONAL UNITS</button>
+        <button id = "groups" class = "blueButton">GROUPS</button> 
+        <button id = "users" class = "blueButton">USERS</button>
+    </a>
+
+</body>
+</html>

--- a/STEP_Project/popup.html
+++ b/STEP_Project/popup.html
@@ -6,7 +6,7 @@
 <body>
     <p>Preferred Entity Selector</p>
     <button id = "addRemove" class = "blueButton">ADD/REMOVE PREFERRED ORG UNIT</button>
-    <a href = preferred.html> 
+    <a href = entitySelect.html> 
     	<button id = "select" class = "blueButton">SELECT A PREFERRED ORG UNIT</button> 
 	</a>
     <script src = "popup.js"></script>

--- a/STEP_Project/preferred.html
+++ b/STEP_Project/preferred.html
@@ -6,7 +6,7 @@
 </head>
 
 <body>
-    <a class = "backButton" href = "popup.html"> &#x2190; </a>
+    <a class = "backButton" href = "entitySelect.html"> &#x2190; </a>
     <p> Preferred Entity Selector </p>
     <form class = "radioButtons" id = "radioButtons"> </form>
     <button id = "apply" class = "blueButton"> APPLY </button>


### PR DESCRIPTION
# entitySelect.html

- Improve flexibility by allowing users to pick whether they want to open settings for their preferred OUs, groups, or users. 
- User Journey:
1. popup home page (popup.html)
<img width="309" alt="Screen Shot 2020-07-14 at 10 56 48 AM" src="https://user-images.githubusercontent.com/44329307/87387732-f56a5280-c5c0-11ea-9ab6-5e295dc8387d.png">

2. Select entity type page (entititySelect.js)
<img width="309" alt="Screen Shot 2020-07-14 at 10 56 55 AM" src="https://user-images.githubusercontent.com/44329307/87387740-f8654300-c5c0-11ea-8aad-557bcaef80d2.png">

3. Choose preferred entity from radio button form (preferred.html)
<img width="314" alt="Screen Shot 2020-07-14 at 10 57 07 AM" src="https://user-images.githubusercontent.com/44329307/87387748-fc916080-c5c0-11ea-8c73-9096bbabbb59.png">

- The back buttons navigate to the immediately previous page. 
- Styling is consistent with the other two popup windows.



