### PR TITLE
Integrate add/remove entities with storage to adapt to users and groups

### DIFF
--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -32,14 +32,14 @@ function addEntity(row, dataid)
     //if entitiy is a user
     else if (row.getAttribute('data-url') !== null)
     {
-        dataname = (row.children[1].children[1].children[0].children[1].children[0].getAttribute('title'));
+        dataname = (row.children[1].children[1].firstChild.children[1].firstChild.getAttribute('title'));
         key = 'user-' + dataid;
     }
 
     //if entity is an OU
-    else if (row.children[0].children[0] !== undefined) //if there is an entity tree in the DOM
+    else if (row.firstChild.firstChild !== undefined) //if there is an entity tree in the DOM
     {
-        dataname = row.children[0].children[0].children[0].children[1].innerHTML;
+        dataname = row.firstChild.firstChild.firstChild.children[1].innerHTML;
         key = 'OU-' + dataid;  
     }
 

--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -30,7 +30,7 @@ function addEntity(row, dataid)
     }
 
     //if entitiy is a user
-    else if (row.getAttribute('data-url') !== null)
+    else if (row.dataset.url != null)
     {
         dataname = (row.children[1].children[1].firstChild.children[1].firstChild.getAttribute('title'));
         key = 'user-' + dataid;
@@ -64,7 +64,7 @@ function removeEntity(row, dataid)
     }
 
     //entity is a user
-    else if (row.getAttribute('data-url') !== null)
+    else if (row.dataset.url != null)
     {
         key = 'user-' + dataid;
     }
@@ -140,7 +140,7 @@ function addButtonsToRows(data)
             }
 
             //entity is a user
-            else if (row.getAttribute('data-url') !== null)
+            else if (row.dataset.url != null)
             {
                 dataname = data['user-' + dataid];
             }

--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -179,6 +179,14 @@ function addButtonsToRows(data)
         
             //add +/- button to row
             row.appendChild(button);
+
+             //styling
+             button.style.fontSize = "22px";
+             button.style.right = "20px";
+             button.style.color = "rgba(0,0,0,0.87)";
+             button.style.position = "relative";
+             button.style.border = "none";
+             button.style.cursor = "pointer";
         }
     }
 }

--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -19,28 +19,28 @@ function addEntity(row, dataid)
     //if DOM structure is not as expected
     if (row === undefined || row.firstChild === undefined)
     {
-        alert("error in DOM");
+        alert('error in DOM');
     }
 
     //if entity is a group
-    else if (row.getAttribute("data-group-name") !== null)
+    else if (row.getAttribute('data-group-name') !== null)
     {
-        dataname = row.getAttribute("data-group-name");
-        key = "group-" + dataid;
+        dataname = row.getAttribute('data-group-name');
+        key = 'group-' + dataid;
     }
 
     //if entitiy is a user
-    else if (row.getAttribute("data-url") !== null)
+    else if (row.getAttribute('data-url') !== null)
     {
-        dataname = (row.children[1].children[1].children[0].children[1].children[0].getAttribute('title'))
-        key = "user-" + dataid;
+        dataname = (row.children[1].children[1].children[0].children[1].children[0].getAttribute('title'));
+        key = 'user-' + dataid;
     }
 
     //if entity is an OU
     else if (row.children[0].children[0] !== undefined) //if there is an entity tree in the DOM
     {
         dataname = row.children[0].children[0].children[0].children[1].innerHTML;
-        key = "OU-" + dataid;  
+        key = 'OU-' + dataid;  
     }
 
     storageObj.set({[key]: dataname});
@@ -58,21 +58,21 @@ function removeEntity(row, dataid)
     var key = dataid;
     
     //entity is a group
-    if (row.getAttribute("data-group-name") !== null)
+    if (row.getAttribute('data-group-name') !== null)
     {
-        key = "group-" + dataid;
+        key = 'group-' + dataid;
     }
 
     //entity is a user
-    else if (row.getAttribute("data-url") !== null)
+    else if (row.getAttribute('data-url') !== null)
     {
-        key = "user-" + dataid;
+        key = 'user-' + dataid;
     }
 
     //entitiy is an OU
     else
     {
-        key = "OU-" + dataid;
+        key = 'OU-' + dataid;
     }
     
     storageObj.remove(key);
@@ -134,32 +134,32 @@ function addButtonsToRows(data)
             let dataname;
 
             //entity is a group
-            if (row.getAttribute("data-group-name") !== null)
+            if (row.getAttribute('data-group-name') !== null)
             {
-                dataname = data["group-" + dataid];
+                dataname = data['group-' + dataid];
             }
 
             //entity is a user
-            else if (row.getAttribute("data-url") !== null)
+            else if (row.getAttribute('data-url') !== null)
             {
-                dataname = data["user-" + dataid];
+                dataname = data['user-' + dataid];
             }
 
             //entity is an OU
             else
             {
-                dataname = data["OU-" + dataid];
+                dataname = data['OU-' + dataid];
             }
             
             button.setAttribute('class','pClass');
             if (dataname !== undefined)
             {
-                button.innerHTML = "-";
+                button.innerHTML = '-';
                 button.setAttribute('class','mClass');
             }
             else
             {
-                button.innerHTML = "+";
+                button.innerHTML = '+';
             }              
             row = entities[i];
             
@@ -171,7 +171,7 @@ function addButtonsToRows(data)
             }
         
             //add +/- button to row
-            row.appendChild(button)
+            row.appendChild(button);
         }
     }
 }
@@ -191,7 +191,7 @@ function addButtons()
  */
 function monitorChanges()
 {
-    // let allRowNodes = document.querySelectorAll("tbody[role=rowgroup]");
+    // let allRowNodes = document.querySelectorAll('tbody[role=rowgroup]');
     let allRowNodes = document.querySelectorAll('tbody');
 
     let rootNode = allRowNodes[0];

--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -37,12 +37,11 @@ function addEntity(row, dataid)
     }
 
     //if entity is an OU
-    else if (row.firstChild.firstChild !== undefined) //if there is an entity tree in the DOM
+    else if (row.firstChild.children[0] != undefined) //if there is an entity tree in the DOM
     {
         dataname = row.firstChild.firstChild.firstChild.children[1].innerHTML;
         key = 'OU-' + dataid;  
     }
-
     storageObj.set({[key]: dataname});
 }
 
@@ -70,11 +69,10 @@ function removeEntity(row, dataid)
     }
 
     //entitiy is an OU
-    else
+    else if (row.firstChild.children[0] !== undefined)
     {
         key = 'OU-' + dataid;
     }
-    
     storageObj.remove(key);
 }
 
@@ -146,7 +144,7 @@ function addButtonsToRows(data)
             }
 
             //entity is an OU
-            else
+            else if (row.children.length !== 0)
             {
                 dataname = data['OU-' + dataid];
             }

--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -11,6 +11,9 @@ if (chrome.storage !== undefined)
  */
 function addEntity(row, dataid)
 {
+    let entityURL = document.getElementsByTagName("link")[0];
+    let entityPage = entityURL.getAttribute("href").split('ac/')[1];
+
     event.target.innerHTML = '-';
     event.target.setAttribute('class','mClass'); 
     let dataname = ''; 
@@ -23,21 +26,21 @@ function addEntity(row, dataid)
     }
 
     //if entity is a group
-    else if (row.getAttribute('data-group-name') !== null)
+    else if (entityPage === "groups")
     {
         dataname = row.getAttribute('data-group-name');
         key = 'group-' + dataid;
     }
 
     //if entitiy is a user
-    else if (row.dataset.url != null)
+    else if (entityPage === "users")
     {
         dataname = (row.children[1].children[1].firstChild.children[1].firstChild.getAttribute('title'));
         key = 'user-' + dataid;
     }
 
     //if entity is an OU
-    else if (row.firstChild.children[0] != undefined) //if there is an entity tree in the DOM
+    else if (entityPage === "orgunits")
     {
         dataname = row.firstChild.firstChild.firstChild.children[1].innerHTML;
         key = 'OU-' + dataid;  
@@ -52,24 +55,27 @@ function addEntity(row, dataid)
  */
 function removeEntity(row, dataid)
 {
+    let entityURL = document.getElementsByTagName("link")[0];
+    let entityPage = entityURL.getAttribute("href").split('ac/')[1];
+
     event.target.innerHTML = '+';
     event.target.setAttribute('class','pClass');
     var key = dataid;
     
     //entity is a group
-    if (row.getAttribute('data-group-name') !== null)
+    if (entityPage === "groups")
     {
         key = 'group-' + dataid;
     }
 
     //entity is a user
-    else if (row.dataset.url != null)
+    else if (entityPage === "users")
     {
         key = 'user-' + dataid;
     }
 
     //entitiy is an OU
-    else if (row.firstChild.children[0] !== undefined)
+    else if (entityPage === "orgunits")
     {
         key = 'OU-' + dataid;
     }
@@ -108,6 +114,9 @@ function addRemoveButtonClick (event)
  */
 function addButtonsToRows(data)
 {
+    let entityURL = document.getElementsByTagName("link")[0];
+    let entityPage = entityURL.getAttribute("href").split('ac/')[1];
+    
     let tabl = document.querySelector('table[role=grid]');
     let entities = tabl.rows;
     let numEntities = entities.length;
@@ -132,19 +141,19 @@ function addButtonsToRows(data)
             let dataname;
 
             //entity is a group
-            if (row.getAttribute('data-group-name') !== null)
+            if (entityPage === "groups")
             {
                 dataname = data['group-' + dataid];
             }
 
             //entity is a user
-            else if (row.dataset.url != null)
+            else if (entityPage === "users")
             {
                 dataname = data['user-' + dataid];
             }
 
             //entity is an OU
-            else if (row.children.length !== 0)
+            else if (entityPage === "orgunits")
             {
                 dataname = data['OU-' + dataid];
             }

--- a/STEP_Project/OUSelectContent.js
+++ b/STEP_Project/OUSelectContent.js
@@ -44,7 +44,7 @@ function selectClick ()
  */
 function onMessageFunction(request)
 {
-    let queryVar = "[data-content-id='" + request.dataId + "']";
+    let queryVar = '[data-content-id=\'' + request.dataId + '\']';
     let orgUnits = document.querySelectorAll(queryVar);
     orgUnits[0].children[1].firstChild.click();
 }

--- a/STEP_Project/background.js
+++ b/STEP_Project/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onInstalled.addListener(function()
     chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
         chrome.declarativeContent.onPageChanged.addRules([{
             conditions: [new chrome.declarativeContent.PageStateMatcher({
-                pageUrl: {urlMatches: '.*admin.google.com\/(u\/[0-9]+\/)?ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(users)|(groups)|(settings\/serviceonoff)'},
+                pageUrl: {urlMatches: '.*admin.google.com/(u/[0-9]+/)?ac/(appsettings/[0-9]+/.+)|(orgunits)|(users)|(groups)|(settings/serviceonoff)'},
             })
             ],
             actions: [new chrome.declarativeContent.ShowPageAction()]

--- a/STEP_Project/background.js
+++ b/STEP_Project/background.js
@@ -5,7 +5,7 @@ chrome.runtime.onInstalled.addListener(function()
     chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
         chrome.declarativeContent.onPageChanged.addRules([{
             conditions: [new chrome.declarativeContent.PageStateMatcher({
-                pageUrl: {urlMatches: '.*admin.google.com\/(u\/[0-9]+\/)?ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(settings\/serviceonoff)'},
+                pageUrl: {urlMatches: '.*admin.google.com\/(u\/[0-9]+\/)?ac\/(appsettings\/[0-9]+\/.+)|(orgunits)|(users)|(groups)|(settings\/serviceonoff)'},
             })
             ],
             actions: [new chrome.declarativeContent.ShowPageAction()]

--- a/STEP_Project/popup.js
+++ b/STEP_Project/popup.js
@@ -23,11 +23,11 @@ const PAGE_TYPES = {
  */
 function findPageType(givenurl)
 {
-    let orgunitspage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/orgunits/g);
+    let entitypage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/(orgunits)|(users)|(groups)/g);
     let settingspage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/appsettings\/[0-9]+\/.+/g);
     let onoffpage = givenurl.match(/admin.google.com\/(u\/[0-9]\/)?ac\/settings\/serviceonoff.*/g);
     pageType = PAGE_TYPES.OTHER;
-    if (orgunitspage !== null)
+    if (entitypage !== null)
     {
         pageType = PAGE_TYPES.ORG_LIST_PAGE;
     }

--- a/STEP_Project/tests/OUListContentTest.js
+++ b/STEP_Project/tests/OUListContentTest.js
@@ -5,7 +5,7 @@ let tabl;
 let orgUnits;
 let numRows;
 
-describe('Testing the addButtons function', ()=>
+describe('Testing the addButtons function for OU list', ()=>
 {
     let mockChrome;
     beforeEach(function()
@@ -18,10 +18,8 @@ describe('Testing the addButtons function', ()=>
             tabl.insertRow();
         }
         orgUnits = tabl.rows;
-        for (let i = 0; i < numRows; i++)
-        {
-            orgUnits[i].setAttribute('data-row-id', i);
-        }
+        orgUnits[1].setAttribute("data-row-id", "OU-0")
+        orgUnits[2].setAttribute("data-row-id", "OU-1")
         document.body.appendChild(tabl);
 
         //initialize mock storage
@@ -35,7 +33,7 @@ describe('Testing the addButtons function', ()=>
             {
                 for (let key in pair)
                 {
-                    this.dict["OU-"+key] = pair[key];
+                    this.dict[key] = pair[key];
                 }
             },
             remove : function(dataid)
@@ -86,7 +84,7 @@ describe('Testing the addButtons function', ()=>
         plus.click();
 
         //check if OU is in storage
-        expect(mockChrome.dict["OU-1"] !== undefined).toBeTruthy();
+        expect(mockChrome.dict["OU-0"] !== undefined).toBeTruthy();
     });
 
     it('Should change "+" button to a "-" button when clicked', ()=>
@@ -120,7 +118,7 @@ describe('Testing the addButtons function', ()=>
         plus.click();
 
         //check if OU is in storage
-        expect(mockChrome.dict["OU-1"] === undefined).toBeTruthy();
+        expect(mockChrome.dict["OU-0"] === undefined).toBeTruthy();
     });
 
     it('Should change the "-" button to a "+" button when clicked', ()=>
@@ -177,6 +175,140 @@ describe('Testing the addButtons function', ()=>
         minusButtons = row.getElementsByClassName('mClass');
         expect(plusButtons.length+minusButtons.length).toEqual(1); //should not be equal to 2
     });
+});
+
+describe('Testing addButtons function for groups list page', ()=>
+{
+    let mockChrome;
+    beforeEach(function()
+    {
+        numRows = 3;
+        tabl = document.createElement('table');
+        tabl.setAttribute('role', 'grid');
+        for (let i = 0; i < numRows; i++)
+        {
+            tabl.insertRow();
+        }
+        groups = tabl.rows;
+        groups[1].setAttribute("data-row-id", "group-0")
+        groups[2].setAttribute("data-row-id", "group-1")
+        document.body.appendChild(tabl);
+
+        //initialize mock storage
+        mockChrome = {
+            dict: {},
+            get : function(arg1, arg2)
+            {
+                arg2(this.dict);
+            },
+            set : function(pair)
+            {
+                for (let key in pair)
+                {
+                    this.dict[key] = pair[key];
+                }
+            },
+            remove : function(dataid)
+            {
+                this.dict[dataid] = undefined;
+            }
+        };
+
+        //initialize arguments for addButtons
+        storageObj = mockChrome;
+        tabl.addEventListener('click', addRemoveButtonClick);
+    })
+
+    afterEach(function()
+    {
+        tabl.remove();
+    });
+
+    it('Should add/remove from storage for groups', ()=>
+    {
+        //call addButtons with mock Storage
+        addButtons();
+
+        let row = groups[1];
+        let plus = row.getElementsByClassName('pClass')[0];
+
+        //add OU to preferred entities by clicking on plus
+        plus.click();
+
+        //check if OU is in storage
+        expect(mockChrome.dict["group-0"] !== undefined).toBeTruthy();
+
+        //click again to remove OU from storage
+        plus.click();
+        expect(mockChrome.dict["group-0"] === undefined).toBeTruthy();
+    });  
+});
+
+describe('Testing addButtons function for users list page', ()=>
+{
+    let mockChrome;
+    beforeEach(function()
+    {
+        numRows = 3;
+        tabl = document.createElement('table');
+        tabl.setAttribute('role', 'grid');
+        for (let i = 0; i < numRows; i++)
+        {
+            tabl.insertRow();
+        }
+        users = tabl.rows;
+        users[1].setAttribute("data-row-id", "user-0")
+        users[2].setAttribute("data-row-id", "user-1")
+        document.body.appendChild(tabl);
+
+        //initialize mock storage
+        mockChrome = {
+            dict: {},
+            get : function(arg1, arg2)
+            {
+                arg2(this.dict);
+            },
+            set : function(pair)
+            {
+                for (let key in pair)
+                {
+                    this.dict[key] = pair[key];
+                }
+            },
+            remove : function(dataid)
+            {
+                this.dict[dataid] = undefined;
+            }
+        };
+
+        //initialize arguments for addButtons
+        storageObj = mockChrome;
+        tabl.addEventListener('click', addRemoveButtonClick);
+    })
+
+    afterEach(function()
+    {
+        tabl.remove();
+    });
+
+    it('Should add/remove from storage for users', ()=>
+    {
+        //call addButtons with mock Storage
+        addButtons();
+
+        let row = users[1];
+        let plus = row.getElementsByClassName('pClass')[0];
+
+        //add OU to preferred entities by clicking on plus
+        plus.click();
+
+        //check if OU is in storage
+        expect(mockChrome.dict["user-0"] !== undefined).toBeTruthy();
+
+        //click again to remove OU from storage
+        plus.click();
+        expect(mockChrome.dict["user-0"] === undefined).toBeTruthy();
+    });  
 });
 
 describe('Testing monitorChanges function (mutation observer)', ()=>{

--- a/STEP_Project/tests/OUListContentTest.js
+++ b/STEP_Project/tests/OUListContentTest.js
@@ -35,12 +35,12 @@ describe('Testing the addButtons function', ()=>
             {
                 for (let key in pair)
                 {
-                    mockChrome.dict[key] = pair[key];
+                    this.dict["OU-"+key] = pair[key];
                 }
             },
             remove : function(dataid)
             {
-                this.dict[dataid]= undefined;
+                this.dict[dataid] = undefined;
             }
         };
 
@@ -56,7 +56,7 @@ describe('Testing the addButtons function', ()=>
 
     it('Should add "+" buttons to all rows except first', ()=>
     {
-    //call addButtons with mock Storage
+        //call addButtons with mock Storage
         addButtons();
         //no buttons on the first (header) row
         let row = orgUnits[0];
@@ -75,7 +75,7 @@ describe('Testing the addButtons function', ()=>
 
     it('Should store OU key-value pair in mock storage when "+" button clicked', ()=>
     {
-    //call addButtons with mock Storage
+        //call addButtons with mock Storage
         addButtons();
 
         let row = orgUnits[1];
@@ -86,12 +86,12 @@ describe('Testing the addButtons function', ()=>
         plus.click();
 
         //check if OU is in storage
-        expect(mockChrome.dict[1] !== undefined).toBeTruthy();
-
+        expect(mockChrome.dict["OU-1"] !== undefined).toBeTruthy();
     });
+
     it('Should change "+" button to a "-" button when clicked', ()=>
     {
-    //call addButtons with mock Storage
+        //call addButtons with mock Storage
         addButtons();
 
         let row = orgUnits[1];
@@ -103,12 +103,11 @@ describe('Testing the addButtons function', ()=>
 
         //button must have become a "-" button
         expect(plus.getAttribute('class')).toEqual('mClass');
-
     });
 
     it('Should remove OU key-value pair from mock storage when "-" button clicked', ()=>
     {
-    //call addButtons with mock Storage
+        //call addButtons with mock Storage
         addButtons();
 
         let row = orgUnits[1];
@@ -121,12 +120,12 @@ describe('Testing the addButtons function', ()=>
         plus.click();
 
         //check if OU is in storage
-        expect(mockChrome.dict[1] === undefined).toBeTruthy();
+        expect(mockChrome.dict["OU-1"] === undefined).toBeTruthy();
     });
 
     it('Should change the "-" button to a "+" button when clicked', ()=>
     {
-    //call addButtons with mock Storage
+        //call addButtons with mock Storage
         addButtons();
         
         let row = orgUnits[1];
@@ -140,7 +139,6 @@ describe('Testing the addButtons function', ()=>
 
         //button must have become "+" button
         expect(plus.getAttribute('class')).toEqual('pClass');
-       
     });
 
     it('Should not add a button to any row that has a button already', ()=>

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -24,10 +24,22 @@ describe('Testing pageType that determines enabling/disabling of buttons dependi
         let pageType = findPageType('https://admin.google.com/u/4/ac/orgunits');
         expect(pageType).toEqual(0);
     });
+
+    it('Should enable Add/Remove button on groups list url (case 0)', ()=>{
+        let pageType = findPageType('https://admin.google.com/u/5/ac/groups');
+        expect(pageType).toEqual(0);
+    });
+
+    it('Should enable Add/Remove button on users list url (case 0)', ()=>{
+        let pageType = findPageType('https://admin.google.com/u/5/ac/users');
+        expect(pageType).toEqual(0);
+    });
+
     it('Should disable extension on any other admin console url (case 2)', ()=>{
         let pageType = findPageType('https://admin.google.com/u/4/ac/apps');
         expect(pageType).toEqual(2);
     });
+
     it('Should disable extension on any other console url (case 2)', ()=>{
         let pageType = findPageType('https://github.com/');
         expect(pageType).toEqual(2);


### PR DESCRIPTION
# Adding users/groups/OUs to Chrome Storage
- The content script **OUListContent.js** identifies whether the user is adding a preferred group, user, or OU.
- This distinction is made by checking the URL in the link tag.
- While re-rendering +/- buttons, a similar method is used to identify users/groups/OUs, and entities already in storage have a "-" button while entities not in storage have a "+" button.
- Changed the format of key-value pairs in storage to accommodate distinction between groups and users. 
- Each key is now of the format "<entity_type>-<data_row_id>"
- Storage now looks as follows:
<img width="234" alt="Screen Shot 2020-07-14 at 1 47 37 PM" src="https://user-images.githubusercontent.com/44329307/87403073-08d5e780-c5da-11ea-93ea-13d877639186.png">


- This implementation improves flexibility: for any other entity that we may want to add in the future, we would simply add another conditional clause. 

# Extending URL enabling
- The extension is now enabled on groups and users list page, by modifications to **popup.js** and **background.js**
- The "add/remove" button is enabled on these pages, and the "select" button is disabled.

# Testing
- Added tests to **popupTest.js**  to check for the extended URL enabling. 
<img width="615" alt="Screen Shot 2020-07-14 at 1 22 30 PM" src="https://user-images.githubusercontent.com/44329307/87402220-df688c00-c5d8-11ea-973c-4c131c314d9b.png">

- Modified **OUListContentTest.js** to accommodate the new storage mechanism.
- Added new tests for users and groups list pages.
<img width="614" alt="Screen Shot 2020-07-14 at 10 34 10 PM" src="https://user-images.githubusercontent.com/44329307/87455277-cf759a00-c622-11ea-9793-0e8cc802288f.png">

# Styling

- **OUListContent.js** has styling code to make +/- buttons clearer and larger. 
- The cursor is changed to a pointer for better UX.
