### PR TITLE
Conditional rendering of preferred entities on respective pages

### DIFF
--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -11,8 +11,8 @@ if (chrome.storage !== undefined)
  */
 function addEntity(row, dataid)
 {
-    let entityURL = document.getElementsByTagName("link")[0];
-    let entityPage = entityURL.getAttribute("href").split('ac/')[1];
+    let entityURL = document.getElementsByTagName('link')[0];
+    let entityPage = entityURL.getAttribute('href').split('ac/')[1];
 
     event.target.innerHTML = '-';
     event.target.setAttribute('class','mClass'); 
@@ -26,21 +26,21 @@ function addEntity(row, dataid)
     }
 
     //if entity is a group
-    else if (entityPage === "groups")
+    else if (entityPage === 'groups')
     {
         dataname = row.getAttribute('data-group-name');
         key = 'group-' + dataid;
     }
 
     //if entitiy is a user
-    else if (entityPage === "users")
+    else if (entityPage === 'users')
     {
         dataname = (row.children[1].children[1].firstChild.children[1].firstChild.getAttribute('title'));
         key = 'user-' + dataid;
     }
 
     //if entity is an OU
-    else if (entityPage === "orgunits")
+    else if (entityPage === 'orgunits')
     {
         dataname = row.firstChild.firstChild.firstChild.children[1].innerHTML;
         key = 'OU-' + dataid;  
@@ -55,27 +55,27 @@ function addEntity(row, dataid)
  */
 function removeEntity(row, dataid)
 {
-    let entityURL = document.getElementsByTagName("link")[0];
-    let entityPage = entityURL.getAttribute("href").split('ac/')[1];
+    let entityURL = document.getElementsByTagName('link')[0];
+    let entityPage = entityURL.getAttribute('href').split('ac/')[1];
 
     event.target.innerHTML = '+';
     event.target.setAttribute('class','pClass');
     var key = dataid;
     
     //entity is a group
-    if (entityPage === "groups")
+    if (entityPage === 'groups')
     {
         key = 'group-' + dataid;
     }
 
     //entity is a user
-    else if (entityPage === "users")
+    else if (entityPage === 'users')
     {
         key = 'user-' + dataid;
     }
 
     //entitiy is an OU
-    else if (entityPage === "orgunits")
+    else if (entityPage === 'orgunits')
     {
         key = 'OU-' + dataid;
     }
@@ -114,8 +114,8 @@ function addRemoveButtonClick (event)
  */
 function addButtonsToRows(data)
 {
-    let entityURL = document.getElementsByTagName("link")[0];
-    let entityPage = entityURL.getAttribute("href").split('ac/')[1];
+    let entityURL = document.getElementsByTagName('link')[0];
+    let entityPage = entityURL.getAttribute('href').split('ac/')[1];
     
     let tabl = document.querySelector('table[role=grid]');
     let entities = tabl.rows;
@@ -141,19 +141,19 @@ function addButtonsToRows(data)
             let dataname;
 
             //entity is a group
-            if (entityPage === "groups")
+            if (entityPage === 'groups')
             {
                 dataname = data['group-' + dataid];
             }
 
             //entity is a user
-            else if (entityPage === "users")
+            else if (entityPage === 'users')
             {
                 dataname = data['user-' + dataid];
             }
 
             //entity is an OU
-            else if (entityPage === "orgunits")
+            else if (entityPage === 'orgunits')
             {
                 dataname = data['OU-' + dataid];
             }
@@ -180,13 +180,13 @@ function addButtonsToRows(data)
             //add +/- button to row
             row.appendChild(button);
 
-             //styling
-             button.style.fontSize = "22px";
-             button.style.right = "20px";
-             button.style.color = "rgba(0,0,0,0.87)";
-             button.style.position = "relative";
-             button.style.border = "none";
-             button.style.cursor = "pointer";
+            //styling
+            button.style.fontSize = '22px';
+            button.style.right = '20px';
+            button.style.color = 'rgba(0,0,0,0.87)';
+            button.style.position = 'relative';
+            button.style.border = 'none';
+            button.style.cursor = 'pointer';
         }
     }
 }

--- a/STEP_Project/OUListContent.js
+++ b/STEP_Project/OUListContent.js
@@ -206,7 +206,6 @@ function addButtons()
  */
 function monitorChanges()
 {
-    // let allRowNodes = document.querySelectorAll('tbody[role=rowgroup]');
     let allRowNodes = document.querySelectorAll('tbody');
 
     let rootNode = allRowNodes[0];
@@ -219,12 +218,12 @@ function monitorChanges()
     });
 
     observer.observe(rootNode, 
-        {
-            attributes: false,
-            childList: true,
-            characterData: false,
-            subtree: true
-        });
+    {
+        attributes: false,
+        childList: true,
+        characterData: false,
+        subtree: true
+    });
 }
 
 (function()

--- a/STEP_Project/entitySelect.html
+++ b/STEP_Project/entitySelect.html
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<link href="./style.css" rel="stylesheet" >
+    <link href="./style.css" rel="stylesheet" >
 </head>
 <body>
     <p>Preferred Entity Selector</p>
     <a class = "backButton" href = "popup.html"> &#x2190; </a>
     
     <a href = preferred.html> 
-        <button id = "OUs" class = "blueButton">ORGANIZATIONAL UNITS</button>
-        <button id = "groups" class = "blueButton">GROUPS</button> 
-        <button id = "users" class = "blueButton">USERS</button>
+        <button id = "OU" class = "blueButton">ORGANIZATIONAL UNITS</button>
+        <button id = "group" class = "blueButton">GROUPS</button> 
+        <button id = "user" class = "blueButton">USERS</button>
     </a>
 
+    <script src = "entitySelect.js"></script>
 </body>
 </html>

--- a/STEP_Project/entitySelect.js
+++ b/STEP_Project/entitySelect.js
@@ -1,0 +1,26 @@
+let storageObj;
+if (chrome.storage !== undefined)
+{
+    storageObj = chrome.storage.sync;
+}
+
+function identifyEntityClass(button)
+{
+    button.addEventListener('click',function(e)
+    {
+        let entity = e.target.getAttribute('id');
+        storageObj.set({'entity-to-display': entity});
+    });
+}
+
+(function()
+{
+    let OUButton = document.getElementById('OU');
+    let groupButton = document.getElementById('group');
+    let userButton = document.getElementById('user');
+
+    identifyEntityClass(OUButton);
+    identifyEntityClass(groupButton);
+    identifyEntityClass(userButton);
+}()
+);

--- a/STEP_Project/preferred.js
+++ b/STEP_Project/preferred.js
@@ -26,31 +26,30 @@ function createForm()
             let urlQueries = url.split('ac')[1].split('?')[1];
 
             let keys = Object.keys(data);
-            let numKeys = keys.length;
 
             let selectForm = document.getElementById('radioButtons');
 
             let entityToDisplay = data['entity-to-display'];
 
-            for (let i = 0; i < numKeys; i++)
+            keys.forEach((key) => 
             {
-                if (keys[i] == 'entity-to-display')
+                if (key == 'entity-to-display')
                 {
-                    continue;
+                    return;
                 }
 
                 let elt = document.createElement('input');
                 elt.setAttribute('type', 'radio');
-                elt.setAttribute('value', keys[i]);
+                elt.setAttribute('value', key);
                 elt.setAttribute('name', 'preferred');
 
-                let prefEntity = keys[i].split('-')[0];
+                let prefEntity = key.split('-')[0];
 
-                let entityName = document.createTextNode(data[keys[i]]);
+                let entityName = document.createTextNode(data[key]);
                 var a = document.createElement('a');
                 a.appendChild(elt);
                 a.append(entityName);
-                a.title = data[keys[i]];
+                a.title = data[key];
 
                 if (prefEntity == entityToDisplay)
                 {
@@ -62,20 +61,20 @@ function createForm()
                     }
                     if (prefEntity == 'group')
                     {
-                        a.href = urlRoot + 'groups/' + keys[i].split('-')[1] + '?' + urlQueries;
+                        a.href = urlRoot + 'groups/' + key.split('-')[1] + '?' + urlQueries;
                         selectForm.appendChild(a);
                         let breakLine = document.createElement('br');
                         selectForm.appendChild(breakLine);
                     }
                     if (prefEntity == 'user')
                     {
-                        a.href = urlRoot + 'users/' + keys[i].split('-')[1] + '?' + urlQueries;
+                        a.href = urlRoot + 'users/' + key.split('-')[1] + '?' + urlQueries;
                         selectForm.appendChild(a);
                         let breakLine = document.createElement('br');
                         selectForm.appendChild(breakLine);
                     }
-                }
-            }
+                }                
+            });
         });
     });
 }

--- a/STEP_Project/tests/entitySelectTest.html
+++ b/STEP_Project/tests/entitySelectTest.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Testing with Jasmine</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine-html.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/boot.min.js"></script>
+    <script src="entitySelectTest.js"></script>
+    <script src="../entitySelect.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/STEP_Project/tests/entitySelectTest.js
+++ b/STEP_Project/tests/entitySelectTest.js
@@ -1,0 +1,71 @@
+describe('Testing selectClick function called when "select" button is clicked', ()=>
+{
+    let mockChrome;
+    beforeAll(function()
+    {
+        //initialize mock storage to mimic chrome.storage.sync
+        mockChrome = 
+        {
+            dict: {},
+            get : function(arg1, arg2)
+            {
+                arg2(this.dict);
+            },
+            set : function(pair)
+            {
+                for (let key in pair)
+                {
+                    this.dict[key] = pair[key];
+                }
+            },
+            remove : function(dataid)
+            {
+                this.dict[dataid]= undefined;
+            }
+        };
+
+        //initialize the UL to mimic the DOM of the settings page
+        numRows = 3;
+        tabl = document.createElement('ul');
+        tabl.setAttribute("role", "group");
+        for (let i = 0; i < numRows; i++)
+        {
+            const liObj = document.createElement('li');
+            const entry = document.createElement('div');
+            liObj.innerText = "row"+i;
+            entry.setAttribute("data-node-id", i);
+            liObj.appendChild(entry);
+            tabl.appendChild(liObj);
+            mockChrome.set({[i]:liObj.innerText})
+        }
+        document.body.appendChild(tabl);
+        storageObj = mockChrome;
+    })
+
+    afterAll(function()
+    {
+        tabl.remove();
+    })
+    
+    it('Should update the mock storage if entity\'s name is changed', ()=>
+    {
+        tabl = document.querySelector('ul[role=group]'); 
+        orgUnits = document.getElementsByTagName("li");
+        row = orgUnits[1];
+        //save children in temporary variable as changing innerText modifies the node
+        let childDiv = row.children[0];
+
+        //rename OU
+        row.innerText = "renamed";
+
+        //append child back as innerText change has modified the node
+        row.appendChild(childDiv);
+
+        //before selectClick, the dictionary value is row1
+        expect(mockChrome.dict[1]).toEqual("row1");
+        selectClick();
+
+        //after selectClick, the dictionary value has been updated to renamed
+        expect(mockChrome.dict[1]).toEqual("renamed");
+    })
+})

--- a/STEP_Project/tests/preferredTest.js
+++ b/STEP_Project/tests/preferredTest.js
@@ -5,6 +5,19 @@ let selectForm;
 describe('Testing the createForm function', ()=>{
     beforeEach(function()
     {
+        let mockTabs = 
+        {
+            active: null,
+            lastFocusedWindow: null,
+            dict: {active: true, lastFocusedWindow: true},
+            tabs: [{url: 'https://admin.google.com/u/3/ac/users'}],
+            query : function(arg1, arg2)
+            {
+                arg2(this.tabs);
+            },
+        };
+        Tabs = mockTabs;
+
         let mockChrome = 
         {
             dict: {},
@@ -31,10 +44,13 @@ describe('Testing the createForm function', ()=>{
         document.body.appendChild(selectForm);
         selectForm = document.getElementById('radioButtons');
 
-        //adding three items to storage
-        storageObj.set({1: 'org1'});
-        storageObj.set({2: 'org2'});
-        storageObj.set({3: 'org3'});
+        //adding 6 items to storage
+        storageObj.set({'OU-1': 'o1'});
+        storageObj.set({'user-1': 'u1'});
+        storageObj.set({'user-2': 'u2'});
+        storageObj.set({'group-1': 'g1'});
+        storageObj.set({'group-2': 'g2'});
+        storageObj.set({'group-3': 'g3'});
     });
 
     afterEach(function()
@@ -42,7 +58,40 @@ describe('Testing the createForm function', ()=>{
         document.getElementById('radioButtons').remove();
     });
     
-    it('Should have as many valid items as in storage', ()=>{
+    it('Should have as many valid OUs as in storage', ()=>{
+        storageObj.set({'entity-to-display': 'OU'});
+        createForm();
+
+        let numValidItems = 0;
+        for (let i = 0; i < selectForm.length; i++)
+        {
+            if (selectForm[i].parentElement.textContent != 'undefined')
+            {
+                numValidItems = numValidItems + 1;
+            }
+        }
+
+        expect(numValidItems).toEqual(1);
+    });
+
+    it('Should have as many valid users as in storage', ()=>{
+        storageObj.set({'entity-to-display': 'user'});
+        createForm();
+
+        let numValidItems = 0;
+        for (let i = 0; i < selectForm.length; i++)
+        {
+            if (selectForm[i].parentElement.textContent != 'undefined')
+            {
+                numValidItems = numValidItems + 1;
+            }
+        }
+
+        expect(numValidItems).toEqual(2);
+    });
+
+    it('Should have as many valid groups as in storage', ()=>{
+        storageObj.set({'entity-to-display': 'group'});
         createForm();
 
         let numValidItems = 0;
@@ -58,9 +107,9 @@ describe('Testing the createForm function', ()=>{
     });
 
     it('Should not add keys with undefined values/keys that have been removed to the form', ()=>{
-        storageObj.remove(1);
+        storageObj.remove('group-1');
+        storageObj.set({'entity-to-display': 'group'});
         createForm();
-
         let numValidItems = 0;
         for (let i = 0; i < selectForm.length; i++)
         {
@@ -69,12 +118,11 @@ describe('Testing the createForm function', ()=>{
                 numValidItems = numValidItems + 1;
             }
         }
-
         expect(numValidItems).toEqual(2);
     });
 });
 
-describe('Testing the applyFunc function', ()=>{
+describe('Testing the enableApplyButton function', ()=>{
     beforeEach(function()
     {
         let mockChrome = 
@@ -103,10 +151,13 @@ describe('Testing the applyFunc function', ()=>{
         document.body.appendChild(selectForm);
         selectForm = document.getElementById('radioButtons');
 
-        //adding three items to storage
-        storageObj.set({1: 'org1'});
-        storageObj.set({2: 'org2'});
-        storageObj.set({3: 'org3'});
+        //adding 6 items to storage
+        storageObj.set({'OU-1': 'o1'});
+        storageObj.set({'user-1': 'u1'});
+        storageObj.set({'user-2': 'u2'});
+        storageObj.set({'group-1': 'g1'});
+        storageObj.set({'group-2': 'g2'});
+        storageObj.set({'group-3': 'g3'});
 
         let applyButton = document.createElement('button');
         applyButton.setAttribute('id','apply');
@@ -123,7 +174,12 @@ describe('Testing the applyFunc function', ()=>{
     
     it('Should enable applyButton only after one of the radio buttons has been selected', ()=>{
         
+        storageObj.set({'entity-to-display': 'user'});
         createForm();
+        selectForm.addEventListener('click',function(e)
+        {
+            enableApplyButton();
+        })
         let applyButton = document.getElementById('apply');
         expect(applyButton.disabled).toBeTruthy();
         selectForm.click();
@@ -163,10 +219,13 @@ describe('Testing the applyFunc function', ()=>{
         document.body.appendChild(selectForm);
         selectForm = document.getElementById('radioButtons');
 
-        //adding three items to storage
-        storageObj.set({1: 'org1'});
-        storageObj.set({2: 'org2'});
-        storageObj.set({3: 'org3'});
+        //adding 6 items to storage
+        storageObj.set({'OU-1': 'o1'});
+        storageObj.set({'user-1': 'u1'});
+        storageObj.set({'user-2': 'u2'});
+        storageObj.set({'group-1': 'g1'});
+        storageObj.set({'group-2': 'g2'});
+        storageObj.set({'group-3': 'g3'});
     });
 
     afterEach(function()
@@ -175,11 +234,15 @@ describe('Testing the applyFunc function', ()=>{
     });
 
     it('Should return the dataRowId of the chosen entity', ()=>{
+        storageObj.set({'entity-to-display': 'user'});
         createForm();
+        selectForm.addEventListener('click',function(e)
+        {
+            enableApplyButton();
+        })
+
         selectForm[0].checked = true;
-
         let dataRowId = applyFunc();
-
-        expect(dataRowId).toEqual('1');
+        expect(dataRowId).toEqual('user-1');
     });
 });


### PR DESCRIPTION
**entitySelect.js**
- This file contains a function called _identifyEntityClass_ that puts into storage information about which preferred entity's button was clicked. When the file preferred.js is called for conditional rendering of stored entities, it uses this information to only display entities of that class.
- TODO: The testing for this function will be done soon.

**preferred.js**
- The function _createForm_ was modified to allow conditional rendering of preferred entities, as mentioned in the description for entitySelect.js above.
- For groups and users, when an entity is displayed, its name is hyperlinked with the url of its settings page for the convenience of the admin. Clicking it opens up the page in a new browser tab.
- Care was taken to ensure that the url contains the query values that are admin-specific.

**preferredTest.js**
- Because of the changes made to storage as well as the _createForm_ function, the tests had to be modified. 
- The tests now check the conditional rendering of preferred entities, while before it was only necessary to check if the list of OUs were getting rendered.
- I created a mock _chrome.tabs.query_ for testing purposes.

![image](https://user-images.githubusercontent.com/44419819/87640267-1ae39180-c764-11ea-9e8d-042c693de762.png)
