### PR TITLE
Update names and presence of Preferred Groups/Users

### DIFF
--- a/STEP_Project/entitySelectContent.js
+++ b/STEP_Project/entitySelectContent.js
@@ -65,11 +65,11 @@ function onMessageFunction(request)
         document.execCommand('copy');
         document.body.removeChild(copyText);
         let parentDiv;
-        if (prefEntity === "group")
+        if (prefEntity === 'group')
         {
             parentDiv = document.querySelectorAll('[data-index=\'1\']')[0];
         }
-        else if (prefEntity === "user")
+        else if (prefEntity === 'user')
         {
             parentDiv = document.querySelectorAll('[data-index=\'0\']')[0]; 
         }
@@ -82,9 +82,6 @@ function onMessageFunction(request)
                 parentDiv.setAttribute('aria-expanded', 'true'); //mimic DOM behavior
             }
         }
-        
-
-        
     }
 }
 

--- a/STEP_Project/entitySelectContent.js
+++ b/STEP_Project/entitySelectContent.js
@@ -64,6 +64,27 @@ function onMessageFunction(request)
         copyText.select();
         document.execCommand('copy');
         document.body.removeChild(copyText);
+        let parentDiv;
+        if (prefEntity === "group")
+        {
+            parentDiv = document.querySelectorAll('[data-index=\'1\']')[0];
+        }
+        else if (prefEntity === "user")
+        {
+            parentDiv = document.querySelectorAll('[data-index=\'0\']')[0]; 
+        }
+        if (parentDiv !== undefined)
+        {
+            let expandEntity = parentDiv.firstChild.firstChild.firstChild.firstChild;
+            if (parentDiv.getAttribute('aria-expanded') !== true) //if not already expanded
+            {
+                expandEntity.click();
+                parentDiv.setAttribute('aria-expanded', 'true'); //mimic DOM behavior
+            }
+        }
+        
+
+        
     }
 }
 

--- a/STEP_Project/popup.html
+++ b/STEP_Project/popup.html
@@ -6,9 +6,7 @@
 <body>
     <p>Preferred Entity Selector</p>
     <button id = "addRemove" class = "blueButton"> ADD/REMOVE PREFERRED ENTITIES </button>
-    <a href = entitySelect.html> 
-        <button id = "select" class = "blueButton">SELECT A PREFERRED ENTITY</button> 
-    </a>
+    <button id = "select" class = "blueButton">SELECT A PREFERRED ENTITY</button> 
     <script src = "popup.js"></script>
 </body>
 </html>

--- a/STEP_Project/popup.js
+++ b/STEP_Project/popup.js
@@ -34,8 +34,8 @@ function updateNames()
         const keys = Object.keys(data);
         for (let i = 0; i < keys.length; i++)
         {
-            var entityType = keys[i].split("-")[0];
-            if (entityType === "OU")
+            var entityType = keys[i].split('-')[0];
+            if (entityType === 'OU')
             {
                 continue;   //OUs do not have their own pages
             }
@@ -49,9 +49,17 @@ function updateNames()
             {
                 dp = new DOMParser();
                 dom = dp.parseFromString(result, 'text/html');
-                let cwiz = dom.getElementsByTagName("c-wiz");
-                var dataname = cwiz[3].firstChild.firstChild.children[1].children[1].firstChild.firstChild.innerText
-                storageObj.set({[keys[i]]: dataname});
+                let cwiz = dom.getElementsByTagName('c-wiz');
+                let error = dom.getElementById('af-error-container');//present in 404/500 page
+                if(error !== null)
+                {
+                    storageObj.remove(keys[i]);//entity must be removed as it has been deleted
+                }
+                else
+                {
+                    var dataname = cwiz[3].firstChild.firstChild.children[1].children[1].firstChild.firstChild.innerText;
+                    storageObj.set({[keys[i]]: dataname});
+                }
             });
         }
     });

--- a/STEP_Project/popup.js
+++ b/STEP_Project/popup.js
@@ -40,15 +40,15 @@ function updateNames()
                 continue;   //OUs do not have their own pages
             }
 
-            var dataId = keys[i].split("-")[1];
+            var dataId = keys[i].split('-')[1];
             var fetchLink = 'https://admin.google.com/ac/' + entityType + 's/' + dataId;
             fetch(fetchLink).then(r => 
             {
                 return r.text();
             }).then(result => 
             {
-                dp = new DOMParser();
-                dom = dp.parseFromString(result, 'text/html');
+                const dp = new DOMParser();
+                const dom = dp.parseFromString(result, 'text/html');
                 let cwiz = dom.getElementsByTagName('c-wiz');
                 let error = dom.getElementById('af-error-container');//present in 404/500 page
                 if(error !== null)
@@ -88,15 +88,15 @@ function findPageType(givenurl)
 
         if (entityPageOU !== null)
         {
-            addRemoveButton.innerHTML = "ADD/REMOVE PREFERRED ORG UNITS";
+            addRemoveButton.innerHTML = 'ADD/REMOVE PREFERRED ORG UNITS';
         }
         else if (entityPageUser !== null)
         {
-            addRemoveButton.innerHTML = "ADD/REMOVE PREFERRED USERS";
+            addRemoveButton.innerHTML = 'ADD/REMOVE PREFERRED USERS';
         }
         else if (entityPageGroup !== null)
         {
-            addRemoveButton.innerHTML = "ADD/REMOVE PREFERRED GROUPS";
+            addRemoveButton.innerHTML = 'ADD/REMOVE PREFERRED GROUPS';
         }
     }
     else if (settingspage !== null || onoffpage !== null)
@@ -155,7 +155,7 @@ function disableButtons(selectButton, addRemoveButton, pageType)
             addRemoveButton.classList.add('disabled');
             addRemoveButton.disabled = true;
         }
-        let buttonLink = document.createElement('a');
+        const buttonLink = document.createElement('a');
         buttonLink.setAttribute('href', 'entitySelect.html');
         selectButton.parentElement.appendChild(buttonLink);
         buttonLink.appendChild(selectButton);

--- a/STEP_Project/preferred.js
+++ b/STEP_Project/preferred.js
@@ -53,6 +53,7 @@ function createForm()
                     elt.setAttribute('type', 'radio');
                     elt.setAttribute('value', key);
                     elt.setAttribute('name', 'preferred');
+                    elt.setAttribute('id', data[key]);
 
                     let prefEntity = key.split('-')[0];
 

--- a/STEP_Project/tests/popupTest.js
+++ b/STEP_Project/tests/popupTest.js
@@ -18,7 +18,7 @@ describe('Testing pageType that determines enabling/disabling of buttons dependi
 
     afterEach(function()
     {
-        restoreDOM();
+        restoreOriginalDOM();
     });
 
     it('Should enable Settings button on appSettings url (case 1)', ()=>{
@@ -75,7 +75,7 @@ function initTest()
     document.body.appendChild(selectButton);
 }
 
-function restoreDOM()
+function restoreOriginalDOM()
 {
     document.getElementById('select').remove();
     document.getElementById('addRemove').remove();
@@ -95,7 +95,7 @@ describe('Testing enabling and disabling of buttons depending on pageType', ()=>
 
     afterEach(function()
     {
-        restoreDOM();
+        restoreOriginalDOM();
     });
 
     it('Should disable add/remove button on settings url for pageType 1', () => {


### PR DESCRIPTION
# Renaming Problem:
- If a Group or a User is renamed, since they are not in the DOM of the settings page, their name is not updated. 
- Additionally, if a group or a user is deleted, their name still appears as a preferred entity. 

# Solution:
- We use the **fetch** API to get the group/user's individual settings page. 
- If the group/user has not been deleted, the page contains the new and updated name of the entity, and we hence update chrome's storage with the new name. 
- If the group/user has been deleted, there is an error container in the DOM of the error page when we fetch it. We use this to detect deletion, and remove the entity from our storage. 
- We perform this _fetch and update_ approach every time the admin clicks on the extension. This way, our storage remains up to date by the time the admin accesses their preferred entity list. It is implemented in **popup.js**.

# Expansion functionality
- When the **Copy** button is clicked for a user/group, the respective search bars are expanded, so that the admin can easily paste the copied name.
- If the tree is already expanded, it remains the way it is.
